### PR TITLE
Algorithmic speed up

### DIFF
--- a/Join_the_dots.py
+++ b/Join_the_dots.py
@@ -25,12 +25,14 @@ def most_similar(positive=[], negative=[], topn=5, noise=0):
         negative = [negative] # broadcast to list
     mp3_vec_i = np.sum([mp3tovec[i] for i in positive] + [-mp3tovec[i] for i in negative], axis=0)
     mp3_vec_i += np.random.normal(0, noise * np.linalg.norm(mp3_vec_i), len(mp3_vec_i))
+    mp3_vec_i_norm = np.linalg.norm(mp3_vec_i) # precalculate norms for mp3_vec_i
     similar = []
     for track_j in mp3tovec:
         if track_j in positive or track_j in negative:
             continue
         mp3_vec_j = mp3tovec[track_j]
-        cos_proximity = np.dot(mp3_vec_i, mp3_vec_j) / (np.linalg.norm(mp3_vec_i) * np.linalg.norm(mp3_vec_j))
+        mp3_vec_j_norm = mp3_vec_j_norms[track_j]
+        cos_proximity = np.dot(mp3_vec_i, mp3_vec_j) / (mp3_vec_i_norm * mp3_vec_j_norm)
         similar.append((track_j, cos_proximity))
     return sorted(similar, key=lambda x:-x[1])[:topn]
 
@@ -41,10 +43,12 @@ def most_similar_by_vec(positive=[], negative=[], topn=5, noise=0):
         negative = [negative] # broadcast to list
     mp3_vec_i = np.sum([i for i in positive] + [-i for i in negative], axis=0)
     mp3_vec_i += np.random.normal(0, noise * np.linalg.norm(mp3_vec_i), len(mp3_vec_i))
+    mp3_vec_i_norm = np.linalg.norm(mp3_vec_i) # precalculate norms for mp3_vec_i
     similar = []
     for track_j in mp3tovec:
         mp3_vec_j = mp3tovec[track_j]
-        cos_proximity = np.dot(mp3_vec_i, mp3_vec_j) / (np.linalg.norm(mp3_vec_i) * np.linalg.norm(mp3_vec_j))
+        mp3_vec_j_norm = mp3_vec_j_norms[track_j]
+        cos_proximity = np.dot(mp3_vec_i, mp3_vec_j) / (mp3_vec_i_norm * mp3_vec_j_norm)
         similar.append((track_j, cos_proximity))
     return sorted(similar, key=lambda x:-x[1])[:topn]
 
@@ -93,6 +97,9 @@ if __name__ == '__main__':
     mix_filename = args.output
     n = args.n
     mp3tovec = pickle.load(open(mp3tovec_filename, 'rb'))
+    mp3_vec_j_norms = {} # precalculate norms for mp3_vec_j
+    for track_j in mp3tovec:
+        mp3_vec_j_norms[track_j] = np.linalg.norm(mp3tovec[track_j])
     noise = 0
     if args.noise is not None:
         noise = args.noise

--- a/MP3ToVec.py
+++ b/MP3ToVec.py
@@ -143,12 +143,9 @@ if __name__ == '__main__':
             with tqdm(mp3_vecs, unit="vector") as t:
                 for i, mp3_vec_i in enumerate(t):
                     for j , mp3_vec_j in enumerate(mp3_vecs):
-                        if i > j:
-                            cos_distances[i, j] = cos_distances[j, i] # I've been here before
-                        elif i < j:
+                        if i < j:
                             cos_distances[i, j] = 1 - np.dot(mp3_vec_i, mp3_vec_j)
-                        else:
-                            cos_distances[i, j] = 0 # i == j
+            cos_distances = cos_distances + cos_distances.T - np.diag(np.diag(cos_distances)) # Make matrix symmetrical diagonally
         except KeyboardInterrupt:
             t.close() # stop the progress bar from sprawling all over the place after a keyboard interrupt
             raise


### PR DESCRIPTION
Join_the_dots can be sped up by 3.5x by precalculting the normalization values for the mp3_vec_i and mp3_vec_j
Tested with a playlist size of 10000
timeit code:
```import numpy as np
import timeit

setup = '''
import numpy as np
mp3tovec = {}
np.random.seed(42)
for i in range(10000):
    vec = np.random.uniform(low=-16, high=16, size=100).astype(np.float16)
    mp3tovec[f'filename-{i}'] = vec
mp3_vec_j_norms = {}
for track_j in mp3tovec:
  mp3_vec_j_norms[track_j] = np.linalg.norm(mp3tovec[track_j])
topn=5
noise=0
positive = ['filename-1'] # broadcast to list
negative = [] # broadcast to list
'''

stmt_original = '''
mp3_vec_i = np.sum([mp3tovec[i] for i in positive] + [-mp3tovec[i] for i in negative], axis=0)
mp3_vec_i += np.random.normal(0, noise * np.linalg.norm(mp3_vec_i), len(mp3_vec_i))
similar = []
for track_j in mp3tovec:
  if track_j in positive or track_j in negative:
    continue
  mp3_vec_j = mp3tovec[track_j]
  cos_proximity = np.dot(mp3_vec_i, mp3_vec_j) / (np.linalg.norm(mp3_vec_i) * np.linalg.norm(mp3_vec_j))
  similar.append((track_j, cos_proximity))
sorted(similar, key=lambda x:-x[1])[:topn]
'''

stmt_improved = '''
mp3_vec_i = np.sum([mp3tovec[i] for i in positive] + [-mp3tovec[i] for i in negative], axis=0)
mp3_vec_i += np.random.normal(0, noise * np.linalg.norm(mp3_vec_i), len(mp3_vec_i))
mp3_vec_i_norm = np.linalg.norm(mp3_vec_i)
similar = []
for track_j in mp3tovec:
  if track_j in positive or track_j in negative:
    continue
  mp3_vec_j = mp3tovec[track_j]
  mp3_vec_j_norm = mp3_vec_j_norms[track_j]
  cos_proximity = np.dot(mp3_vec_i, mp3_vec_j) / (mp3_vec_i_norm * mp3_vec_j_norm)
  similar.append((track_j, cos_proximity))
sorted(similar, key=lambda x:-x[1])[:topn]
'''
if __name__ == '__main__':
  iterations = 100
  print(f'Improved: {timeit.timeit(stmt=stmt_improved, setup=setup, number=iterations)}')
  print(f'Original: {timeit.timeit(stmt=stmt_original, setup=setup, number=iterations)}')
```
  
Results:
```
Improved: 1.3627493999956641
Original: 4.834892099999706
```

Precalculating cosine distance can be sped up by 8% by using native numpy functions to copy the matrix across the diagonal axis instead of iterating in a for loop for every element.
timeit code:
```
import numpy as np
import timeit

setup = '''
import numpy as np
mp3s = {}
np.random.seed(42)
for i in range(100):
    vec = [np.random.uniform(low=-255, high=255, size=100).astype(np.float16) for _ in range(50)]
    mp3s[f'filename-{i}'] = vec

mp3_vecs = []
mp3_indices = {}
for mp3 in mp3s:
    mp3_indices[mp3] = []
    for mp3_vec in mp3s[mp3]:
        mp3_indices[mp3].append(len(mp3_vecs))
        mp3_vecs.append(mp3_vec / np.linalg.norm(mp3_vec)) # normalize
num_mp3_vecs = len(mp3_vecs)
'''

stmt_original = '''
cos_distances = np.zeros((num_mp3_vecs, num_mp3_vecs), dtype=np.float16)
for i, mp3_vec_i in enumerate(mp3_vecs):
    for j , mp3_vec_j in enumerate(mp3_vecs):
        if i > j:
            cos_distances[i, j] = cos_distances[j, i] # I've been here before
        elif i < j:
            cos_distances[i, j] = 1 - np.dot(mp3_vec_i, mp3_vec_j)
        else:
            cos_distances[i, j] = 0 # i == j
cos_distances = cos_distances + cos_distances.T - np.diag(np.diag(cos_distances))
del cos_distances
'''

stmt_improved = '''
cos_distances = np.zeros((num_mp3_vecs, num_mp3_vecs), dtype=np.float16)
for i, mp3_vec_i in enumerate(mp3_vecs):
    for j , mp3_vec_j in enumerate(mp3_vecs):
        if i < j:
            cos_distances[i, j] = 1 - np.dot(mp3_vec_i, mp3_vec_j)
cos_distances = cos_distances + cos_distances.T - np.diag(np.diag(cos_distances))
del cos_distances
'''
if __name__ == '__main__':
    iterations = 1
    print(f'Improved: {timeit.timeit(stmt=stmt_improved, setup=setup, number=iterations)}')
    print(f'Original: {timeit.timeit(stmt=stmt_original, setup=setup, number=iterations)}')
```
    
Results:
```
Improved: 26.234350200000335
Original: 28.40217399998801
```
