### PR TITLE
Add support for Intel based MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+venv-deej-ai
 lib/
 lib64
 bin/

--- a/MP3ToVec.py
+++ b/MP3ToVec.py
@@ -15,7 +15,7 @@ import random
 def walkmp3s(folder):
     for dirpath, dirs, files in os.walk(folder, topdown=False):
         for filename in files:
-            if filename[-3:].lower() == 'mp3' or filename[-3:].lower() == 'm4a':
+            if filename.lower().endswith(('.flac', '.mp3', '.m4a')):
                 yield filename, os.path.abspath(os.path.join(dirpath, filename))
 
 if __name__ == '__main__':
@@ -58,7 +58,7 @@ if __name__ == '__main__':
         files = []
         done = os.listdir(dump_directory)
         for filename, full_path in walkmp3s(mp3_directory):
-            pickle_filename = (full_path[:-3]).replace('\\', '_').replace('/', '_').replace(':','_') + 'p'
+            pickle_filename = os.path.splitext(full_path)[0].replace('\\', '_').replace('/', '_').replace(':','_') + '.p'
             if pickle_filename in done:
                 continue
             files.append((pickle_filename, full_path))

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Another simple idea is to listen to music using a microphone and to propose a se
 
 ### Try it out for yourself
 
+Avoid python environment hell... set up a virtual sandbox first
+```
+python3 -m venv venv-deej-ai
+source venv-deej-ai/bin/activate
+python -m pip install -U pip
+```
+
 Once you have installed the required python packages with
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ pandas
 numpy
 dash_html_components
 Pillow
-tensorflow
+tensorflow; sys_platform != 'darwin'
+tensorflow-macos; sys_platform == 'darwin'
+tensorflow-metal; sys_platform == 'darwin'
 numba
 markupsafe==2.0.1


### PR DESCRIPTION
Fixes #45 by using conditionals in `requirements.txt` to ensure an appropriate tensorflow version and [metal plugin for MacOS](https://developer.apple.com/metal/tensorflow-plugin/) are installed. Also we're updating the `README` to suggest using a sandbox to avoid creating a mess of the dependencies. 

This was tested on/with:
* MacOS: Sonoma 14.5
* CPU: Core Intel Xeon W
* GPU: Radeon Pro Vega 56
* Python: 3.11.9