### PR TITLE
Fix m3u playlist header and output to relative paths

### DIFF
--- a/Deej-A.I.py
+++ b/Deej-A.I.py
@@ -427,15 +427,28 @@ def update_output(contents, jsonified_data, filename, lookback, noise):
     time.sleep(1)
     return [upload, shared]
 
+def relative_path(fileout, track):
+    # Determine if fileout is a file or directory
+    if os.path.isdir(fileout):
+        fileout_dir = fileout
+    else:
+        fileout_dir = os.path.dirname(fileout)
+
+    # Compute the relative path from fileout directory to tracks
+    relative = os.path.relpath(track, start=fileout_dir)
+    
+    return relative
 
 def tracks_to_m3u(fileout, tracks):
     """
-    using absolute path
+    using relative path
     """
 
     with open(fileout, 'w') as f:
+        f.write("#EXTM3U\n")
         for item in tracks:
-            f.write(item + "\n")
+            relpath = relative_path(fileout, item)
+            f.write(relpath + "\n")
 
 
 if __name__ == '__main__':

--- a/Deej-A.I.py
+++ b/Deej-A.I.py
@@ -490,16 +490,16 @@ if __name__ == '__main__':
         app.run_server(threaded=False, debug=False)
     else:
         if input_song != None:
-            print("Outfile playlist: {}".format(playlist_outfile))
-            print("Input song selected: {}".format(input_song))
-            print("Requested {} songs".format(n_songs))
-
             if n_songs == None:
                 n_songs = default_playlist_size
             if noise == None:
                 noise = default_noise
             if lookback == None:
                 lookback = default_lookback
+
+            print("Outfile playlist: {}".format(playlist_outfile))
+            print("Input song selected: {}".format(input_song))
+            print("Requested {} songs".format(n_songs))
 
             tracks = make_playlist([input_song], size=n_songs + 1, noise=noise, lookback=lookback)
             tracks_to_m3u(playlist_outfile, tracks)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you are interested in the data I used to train the neural network, feel free 
 
 Optionally you can generate an ```.m3u``` file with relative path to export the playlist and play it on another device.
 
-The playlist file uses relative paths. So if you specifiy `--playlist` as `/home/user/playlists/playlist_outfile.m3u` and one of it's tracks is located at `home/user/music/some_awesome_music.mp3` the resulting playlist will write that track out as `../music/some_awesome_music.mp3`.
+The playlist file uses relative paths. So if you specifiy `--playlist` as `/home/user/playlists/playlist_outfile.m3u` and one of its tracks is located at `/home/user/music/some_awesome_music.mp3` the resulting playlist will write that track out as `../music/some_awesome_music.mp3`.
 
 Run with:
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you are interested in the data I used to train the neural network, feel free 
 
 Optionally you can generate an ```.m3u``` file with relative path to export the playlist and play it on another device.
 
-The playlist file uses absolute paths.
+The playlist file uses relative paths. So if you specifiy `--playlist` as `/home/user/playlists/playlist_outfile.m3u` and one of it's tracks is located at `home/user/music/some_awesome_music.mp3` the resulting playlist will write that track out as `../music/some_awesome_music.mp3`.
 
 Run with:
 


### PR DESCRIPTION
Improve playlist portability by changing the output of the `--playlist` option so that track paths are relative to the m3u file's location instead of absolute. While we're at it fix the header of the file so that it starts with `#EXTM3U` as per the spec.

An example: If you specifiy `--playlist` as `/home/user/playlists/playlist_outfile.m3u` and one of the selected tracks is located at `home/user/music/some_awesome_music.mp3` the resulting playlist will write that track's location out as `../music/some_awesome_music.mp3`.