### PR TITLE
Support MacOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ pandas
 numpy
 dash_html_components
 Pillow
-tensorflow
+tensorflow; sys_platform != 'darwin'
+tensorflow-macos; sys_platform == 'darwin'
+tensorflow-metal; sys_platform == 'darwin'
 numba
 markupsafe==2.0.1


### PR DESCRIPTION
Fixes https://github.com/teticio/Deej-AI/issues/45 by using conditionals in requirements.txt to ensure an appropriate tensorflow version and [metal plugin for MacOS](https://developer.apple.com/metal/tensorflow-plugin/) are installed. 

This was tested on/with:

**macOS-14.5-x86_64-i386-64bit**
* CPU: Core Intel Xeon W
* GPU: Radeon Pro Vega 56
* Python: 3.11.9

**macOS-14.5-arm64-arm-64bit**
* CPU: Apple M1 Pro
* Python: 3.10.3

